### PR TITLE
Fixed typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Create a composer.json file in your project root:
 ```javascript
     {
         "require": {
-            "rfg/ongage-lib": "0.1*"
+            "rfg/ongage-lib": "0.1.*"
         }
     }
 ```


### PR DESCRIPTION
Otherwise composer throws

Could not parse version constraint 0.1*: Invalid version string "0.1*"